### PR TITLE
Fixed bug

### DIFF
--- a/app/lib/trip/start_trip_page.dart
+++ b/app/lib/trip/start_trip_page.dart
@@ -214,13 +214,12 @@ class _StartTripPageState extends State<StartTripPage>
                     _noMapsDefined = false;
                     _noEartagsDefined = false;
                     _noTiesDefined = false;
-                    _readFarmMaps(_farmDocs[_farmNames.indexOf(newFarmName!)]);
                     setState(() {
-                      _selectedFarmName = newFarmName;
+                      _selectedFarmName = newFarmName!;
                       _feedbackText = '';
                       _eartagAndTieText = '';
-                      updateIcon();
                     });
+                    _readFarmMaps(_farmDocs[_farmNames.indexOf(newFarmName!)]);
                   }
                 })),
         // To fill space of download-icon in _farmMapRow (+ 10 from SizedBox)


### PR DESCRIPTION
Ved gårdsbyutte på start tur-siden forsvinner feedback-teksten når en gård ikke har definert slips/øremerker osv.